### PR TITLE
Test snap coherence from layer-snap fork

### DIFF
--- a/lib/charms/layer/snap.py
+++ b/lib/charms/layer/snap.py
@@ -392,7 +392,7 @@ def _check_refresh_available(snapname):
     return snapname in get_available_refreshes()
 
 
-def create_cohort_snapshop(snapname):
+def create_cohort_snapshot(snapname):
     '''Create a new cohort key for the given snap.
 
     Cohort keys represent a snapshot of the revision of a snap at the time
@@ -413,7 +413,8 @@ def join_cohort_snapshot(snapname, cohort_key):
     '''Refresh the snap into the given cohort.
 
     If the snap was previously in a cohort, this will update the revision
-    to that of the new cohort snapshot.
+    to that of the new cohort snapshot. Note that this does not change the
+    channel that the snap is in, only the revision within that channel.
     '''
     if is_local(snapname):
         # joining a cohort can override a locally installed snap
@@ -422,5 +423,7 @@ def join_cohort_snapshot(snapname, cohort_key):
         return
     subprocess.check_output(['snap', 'refresh', snapname,
                              '--cohort', cohort_key])
+    # even though we just refreshed to the latest in the cohort, it's
+    # slightly possible that there's a newer rev available beyond the cohort
     reactive.toggle_flag(get_refresh_available_flag(snapname),
                          _check_refresh_available(snapname))

--- a/reactive/snap.py
+++ b/reactive/snap.py
@@ -32,7 +32,7 @@ from charmhelpers.core.host import write_file
 from charms import layer
 from charms import reactive
 from charms.layer import snap
-from charms.reactive import register_trigger, when, when_not
+from charms.reactive import register_trigger, when, when_not, toggle_flag
 from charms.reactive.helpers import data_changed
 
 
@@ -83,6 +83,17 @@ def install():
             snap.install(snapname, **snap_opts)
     if data_changed('snap.install.opts', opts):
         snap.connect_all()
+
+
+def check_refresh_available():
+    # Do nothing if we don't have kernel support yet
+    if not kernel_supported():
+        return
+
+    available_refreshes = snap.get_available_refreshes()
+    for snapname in snap.get_installed_snaps():
+        toggle_flag(snap.get_refresh_available_flag(snapname),
+                    snapname in available_refreshes)
 
 
 def refresh():
@@ -332,3 +343,4 @@ hookenv.atstart(ensure_path)
 hookenv.atstart(update_snap_proxy)
 hookenv.atstart(configure_snap_store_proxy)
 hookenv.atstart(install)
+hookenv.atstart(check_refresh_available)


### PR DESCRIPTION
Support for snap coherence is being worked in:

https://bugs.launchpad.net/charm-kubernetes-master/+bug/1845559

For this to work, we need new functions and flags to manage snap cohorts in `layer-snap`.  This has been proposed in:

https://code.launchpad.net/~johnsca/layer-snap/+git/layer-snap/+merge/375315

Since upstream has not yet accepted the above, use this PR to add the required functionality to our `layer-snap` fork so we can test the coherence feature in K8s charms.